### PR TITLE
clang compatibility fixes

### DIFF
--- a/ext/minisat/minisat.c
+++ b/ext/minisat/minisat.c
@@ -277,7 +277,7 @@ static VALUE solver_add_clause_2(VALUE rslv, VALUE rcls)
     }
     else {
       rcls = rb_convert_type(rcls, T_ARRAY, "Array", "to_ary");
-      return solver_add_clause(RARRAY_LEN(rcls), RARRAY_PTR(rcls), rslv);
+      return solver_add_clause((int) RARRAY_LEN(rcls), RARRAY_PTR(rcls), rslv);
     }
 }
 

--- a/minisat/minisat/core/SolverTypes.h
+++ b/minisat/minisat/core/SolverTypes.h
@@ -47,7 +47,7 @@ struct Lit {
     int     x;
 
     // Use this as a constructor:
-    friend Lit mkLit(Var var, bool sign = false);
+    friend Lit mkLit(Var var, bool sign);
 
     bool operator == (Lit p) const { return x == p.x; }
     bool operator != (Lit p) const { return x != p.x; }
@@ -55,16 +55,16 @@ struct Lit {
 };
 
 
-inline  Lit  mkLit     (Var var, bool sign) { Lit p; p.x = var + var + (int)sign; return p; }
-inline  Lit  operator ~(Lit p)              { Lit q; q.x = p.x ^ 1; return q; }
+inline  Lit  mkLit     (Var var, bool sign = false) { Lit p; p.x = var + var + (int)sign; return p; }
+inline  Lit  operator ~(Lit p)               { Lit q; q.x = p.x ^ 1; return q; }
 inline  Lit  operator ^(Lit p, bool b)      { Lit q; q.x = p.x ^ (unsigned int)b; return q; }
 inline  bool sign      (Lit p)              { return p.x & 1; }
 inline  int  var       (Lit p)              { return p.x >> 1; }
 
 // Mapping Literals to and from compact integers suitable for array indexing:
-inline  int  toInt     (Var v)              { return v; } 
-inline  int  toInt     (Lit p)              { return p.x; } 
-inline  Lit  toLit     (int i)              { Lit p; p.x = i; return p; } 
+inline  int  toInt     (Var v)              { return v; }
+inline  int  toInt     (Lit p)              { return p.x; }
+inline  Lit  toLit     (int i)              { Lit p; p.x = i; return p; }
 
 //const Lit lit_Undef = mkLit(var_Undef, false);  // }- Useful special constants.
 //const Lit lit_Error = mkLit(var_Undef, true );  // }

--- a/minisat/minisat/utils/Options.h
+++ b/minisat/minisat/utils/Options.h
@@ -199,7 +199,7 @@ class IntOption : public Option
             return false;
 
         char*   end;
-        int32_t tmp = strtol(span, &end, 10);
+        int32_t tmp = (int32_t) strtol(span, &end, 10);
 
         if (end == NULL) 
             return false;


### PR DESCRIPTION
The default value in the `mkLit` declaration (vs. definition) won't compile with modern clang.  The other minor edits are warning fixes.  This version of minisat is still current with upstream, but minisat PRs with a fix haven't gotten a response in a while.  

Ref: niklasso/minisat#16, niklasso/minisat#22, niklasso/minisat#12, niklasso/minisat#27.  Closes #1
