### PR TITLE
C++11 changes, and some clang fixes

### DIFF
--- a/minisat/minisat/core/Solver.cc
+++ b/minisat/minisat/core/Solver.cc
@@ -209,7 +209,7 @@ void Solver::cancelUntil(int level) {
         for (int c = trail.size()-1; c >= trail_lim[level]; c--){
             Var      x  = var(trail[c]);
             assigns [x] = l_Undef;
-            if (phase_saving > 1 || (phase_saving == 1) && c > trail_lim.last())
+            if ((phase_saving > 1 || (phase_saving == 1)) && (c > trail_lim.last()))
                 polarity[x] = sign(trail[c]);
             insertVarOrder(x); }
         qhead = trail_lim[level];
@@ -499,7 +499,7 @@ CRef Solver::propagate()
 
         NextClause:;
         }
-        ws.shrink(i - j);
+        ws.shrink(int(i - j));
     }
     propagations += num_props;
     simpDB_props -= num_props;
@@ -657,7 +657,7 @@ lbool Solver::search(int nof_conflicts)
 
         }else{
             // NO CONFLICT
-            if (nof_conflicts >= 0 && conflictC >= nof_conflicts || !withinBudget()){
+            if ((nof_conflicts >= 0) && (conflictC >= nof_conflicts || !withinBudget())) {
                 // Reached bound on number of conflicts:
                 progress_estimate = progressEstimate();
                 cancelUntil(0);

--- a/minisat/minisat/mtl/Vec.h
+++ b/minisat/minisat/mtl/Vec.h
@@ -96,7 +96,7 @@ template<class T>
 void vec<T>::capacity(int min_cap) {
     if (cap >= min_cap) return;
     int add = imax((min_cap - cap + 1) & ~1, ((cap >> 1) + 2) & ~1);   // NOTE: grow by approximately 3/2
-    if (add > INT_MAX - cap || ((data = (T*)::realloc(data, (cap += add) * sizeof(T))) == NULL) && errno == ENOMEM)
+    if ((add > INT_MAX - cap || ((data = (T*)::realloc(data, (cap += add) * sizeof(T))) == NULL)) && (errno == ENOMEM))
         throw OutOfMemoryException();
  }
 

--- a/minisat/minisat/utils/Options.h
+++ b/minisat/minisat/utils/Options.h
@@ -282,15 +282,15 @@ class Int64Option : public Option
         if (range.begin == INT64_MIN)
             fprintf(stderr, "imin");
         else
-            fprintf(stderr, "%4"PRIi64, range.begin);
+            fprintf(stderr, "%4" PRIi64, range.begin);
 
         fprintf(stderr, " .. ");
         if (range.end == INT64_MAX)
             fprintf(stderr, "imax");
         else
-            fprintf(stderr, "%4"PRIi64, range.end);
+            fprintf(stderr, "%4" PRIi64, range.end);
 
-        fprintf(stderr, "] (default: %"PRIi64")\n", value);
+        fprintf(stderr, "] (default: %" PRIi64")\n", value);
         if (verbose){
             fprintf(stderr, "\n        %s\n", description);
             fprintf(stderr, "\n");

--- a/minisat/minisat/utils/Options.h
+++ b/minisat/minisat/utils/Options.h
@@ -60,7 +60,7 @@ class Option
     struct OptionLt {
         bool operator()(const Option* x, const Option* y) {
             int test1 = strcmp(x->category, y->category);
-            return test1 < 0 || test1 == 0 && strcmp(x->type_name, y->type_name) < 0;
+            return (test1 < 0 || test1 == 0) && (strcmp(x->type_name, y->type_name) < 0);
         }
     };
 


### PR DESCRIPTION
Has the following fixes:

* C++11 requires a space between literal and identifier, this is a recent change and seems to cause compile errors.
* clang shows warnings when 2 conditions around a `&&` operator doesn't have parenthesis. So just enclosed operations with parenthesis.